### PR TITLE
Add a brief demonstration for visualization with Makie

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+Meshes = "eacbb407-ea5a-433e-ab97-5258b1ca43fa"
 PlyIO = "42171d58-473b-503a-8d5f-782019eb09ec"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -15,4 +16,4 @@ StaticArrays = "0.12, 1"
 julia = "1"
 
 [targets]
-test = ["BenchmarkTools", "PlyIO", "Test"]
+test = ["BenchmarkTools", "Meshes", "PlyIO", "Test"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE.md)
+[![CI](https://github.com/t-bltg/MarchingCubes.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/t-bltg/MarchingCubes.jl/actions/workflows/CI.yml)
 
 # MarchingCubes
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE.md)
-[![CI](https://github.com/t-bltg/MarchingCubes.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/t-bltg/MarchingCubes.jl/actions/workflows/CI.yml)
-[![Coverage Status](https://codecov.io/gh/t-bltg/MarchingCubes.jl/branch/main/graphs/badge.svg?branch=master)](https://app.codecov.io/gh/t-bltg/MarchingCubes.jl) 
+[![CI](https://github.com/JuliaGeometry/MarchingCubes.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/JuliaGeometry/MarchingCubes.jl/actions/workflows/CI.yml)
+[![Coverage Status](https://codecov.io/gh/JuliaGeometry/MarchingCubes.jl/branch/main/graphs/badge.svg)](https://app.codecov.io/gh/JuliaGeometry/MarchingCubes.jl)
+[![MarchingCubes Downloads](https://shields.io/endpoint?url=https://pkgs.genieframework.com/api/v1/badge/MarchingCubes)](https://pkgs.genieframework.com?packages=MarchingCubes)
+
 # MarchingCubes
 
 Julia port of [Efficient Implementation of Marching Cubes' Cases with Topological Guarantees](https://www.tandfonline.com/doi/abs/10.1080/10867651.2003.10487582).
@@ -29,7 +31,7 @@ julia> MarchingCubes.output(PlyIO, mc)  # writes "test.ply" (can be openend in a
 ```
 
 Test scenario output:
-![ParaView Torus](https://github.com/t-bltg/MarchingCubes.jl/raw/marchingcubes-docs/torus.png)
+![ParaView Torus](https://github.com/JuliaGeometry/MarchingCubes.jl/raw/marchingcubes-docs/torus.png)
 
 # Original BibTeX
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ julia> MarchingCubes.output(PlyIO, mc)  # writes "test.ply" (can be openend in a
 ```
 
 Test scenario output:
-![ParaView Torus](https://github.com/JuliaGeometry/MarchingCubes.jl/raw/marchingcubes-docs/torus.png)
+![ParaView Torus](https://github.com/JuliaGeometry/MarchingCubes.jl/raw/marchingcubes-docs/paraview-torus.png)
 
 # MWE demonstrating visualization with Makie.jl
 

--- a/README.md
+++ b/README.md
@@ -34,24 +34,20 @@ Test scenario output:
 ![ParaView Torus](https://github.com/JuliaGeometry/MarchingCubes.jl/raw/marchingcubes-docs/torus.png)
 
 # MWE demonstrating visualization with Makie.jl
+
 ```julia
 using MarchingCubes
 using GLMakie
-using Meshes, MeshViz
-
-function makemesh(mcobj)
-    points = Meshes.Point3[Tuple(pt) for pt in mcobj.vertices]
-    tris = connect.([Tuple(tri) for tri in mcobj.triangles], Triangle)
-    mesh = SimpleMesh(points, [tris;])
-end
+using MeshViz
+using Meshes
 
 mc = MarchingCubes.scenario()
 march(mc)
-mesh = makemesh(mc)
-f = viz(mesh)
-display(f)
+mesh = MarchingCubes.makemesh(Meshes, mc)
+display(viz(mesh))
 ```
 
+![Makie Mesh](https://github.com/JuliaGeometry/MarchingCubes.jl/raw/marchingcubes-docs/makie-mesh.png)
 
 # Original BibTeX
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 Julia port of [Efficient Implementation of Marching Cubes' Cases with Topological Guarantees](https://www.tandfonline.com/doi/abs/10.1080/10867651.2003.10487582).
 
-[Public article](http://thomas.lewiner.org/pdfs/marching_cubes_jgt.pdf).
+Public article available [here](http://thomas.lewiner.org/pdfs/marching_cubes_jgt.pdf).
 
 # Implementation
 
-Adapted to `Julia` (`1`-based indexing) from the original [c++ implementation](http://thomas.lewiner.org/srcs/marching_cubes_jgt.zip) (`0`-based indexing).
+Adapted to `Julia` (`1` based indexing) from the original [c++ implementation](http://thomas.lewiner.org/srcs/marching_cubes_jgt.zip) (`0` based indexing).
 
 # Tiny benchmark
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,26 @@ julia> MarchingCubes.output(PlyIO, mc)  # writes "test.ply" (can be openend in a
 Test scenario output:
 ![ParaView Torus](https://github.com/JuliaGeometry/MarchingCubes.jl/raw/marchingcubes-docs/torus.png)
 
+# MWE demonstrating visualization with Makie.jl
+```julia
+using MarchingCubes
+using GLMakie
+using Meshes, MeshViz
+
+function makemesh(mcobj)
+    points = Meshes.Point3[Tuple(pt) for pt in mcobj.vertices]
+    tris = connect.([Tuple(tri) for tri in mcobj.triangles], Triangle)
+    mesh = SimpleMesh(points, [tris;])
+end
+
+mc = MarchingCubes.scenario()
+march(mc)
+mesh = makemesh(mc)
+f = viz(mesh)
+display(f)
+```
+
+
 # Original BibTeX
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](http://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE.md)
 [![CI](https://github.com/t-bltg/MarchingCubes.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/t-bltg/MarchingCubes.jl/actions/workflows/CI.yml)
-
+[![Coverage Status](https://codecov.io/gh/t-bltg/MarchingCubes.jl/branch/main/graphs/badge.svg?branch=master)](https://app.codecov.io/gh/t-bltg/MarchingCubes.jl) 
 # MarchingCubes
 
 Julia port of [Efficient Implementation of Marching Cubes' Cases with Topological Guarantees](https://www.tandfonline.com/doi/abs/10.1080/10867651.2003.10487582).

--- a/src/MarchingCubes.jl
+++ b/src/MarchingCubes.jl
@@ -320,7 +320,7 @@ Computes almost all the vertices of the mesh by interpolation along the cubes ed
 """
 compute_intersection_points(m::MC{F}, vol, cb, iso) where {F} = begin
     @inbounds for k ∈ axes(vol, 3), j ∈ axes(vol, 2), i ∈ axes(vol, 1)
-        c0 = vol[i, j, k]
+        c0 = vol[i, j, k] - iso
         c1 = i < m.nx ? vol[i+1, j, k] - iso : c0
         c2 = j < m.ny ? vol[i, j+1, k] - iso : c0
         c3 = k < m.nz ? vol[i, j, k+1] - iso : c0

--- a/src/MarchingCubes.jl
+++ b/src/MarchingCubes.jl
@@ -113,7 +113,7 @@ end
 """
     march_legacy(m::MC, isovalue::Number)
 
-# Decription
+# Description
 Original Marching Cubes algorithm.
 
 # Arguments
@@ -143,7 +143,7 @@ end
 """
     march(m::MC, isovalue::Number)
 
-# Decription
+# Description
 Topologically controlled Marching Cubes algorithm.
 
 Arguments

--- a/src/example.jl
+++ b/src/example.jl
@@ -75,3 +75,9 @@ output(PlyIO::Module, m::MC, fn::AbstractString = "test.ply") = begin
     PlyIO.save_ply(ply, fn, ascii = true)
     return
 end
+
+makemesh(Meshes::Module, m::MC) = begin
+    points = Meshes.Point3[Tuple(pt) for pt ∈ m.vertices]
+    tris = Meshes.connect.([Tuple(tri) for tri ∈ m.triangles], Meshes.Triangle)
+    Meshes.SimpleMesh(points, [tris;])
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using BenchmarkTools
 using MarchingCubes
+using Meshes
 using PlyIO
 using Test
 
@@ -73,4 +74,10 @@ end
     @test all(m1.triangles .≈ m2.triangles)
     @test all(m1.vertices .≈ m2.vertices)
     @test all(m1.normals .≈ m2.normals)
+end
+
+@testset "makemesh" begin
+    mc = MarchingCubes.scenario()
+    march(mc)
+    mesh = MarchingCubes.makemesh(Meshes, mc)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,5 +81,5 @@ end
     march(mc)
     mesh = MarchingCubes.makemesh(Meshes, mc)
     @test nvertices(mesh) == length(mc.vertices)
-    @test nelements(mesh.topology) == length(mc.triangles)
+    @test nelements(topology(mesh)) == length(mc.triangles)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -80,4 +80,6 @@ end
     mc = MarchingCubes.scenario()
     march(mc)
     mesh = MarchingCubes.makemesh(Meshes, mc)
+    @test nvertices(mesh) == length(mc.vertices)
+    @test nelements(mesh.topology) == length(mc.triangles)
 end


### PR DESCRIPTION
As we discussed in #7 , here is a MWE demonstrating how to make a Meshes.jl mesh from this mesh structure, so it can be visualized with GLMakie. I am happy to move this to a separate file or elsewhere in the README, and can include an image of the output as well.

Fixes https://github.com/JuliaGeometry/MarchingCubes.jl/issues/7.