### PR TITLE
rework `ply` types for consistency

### DIFF
--- a/src/example.jl
+++ b/src/example.jl
@@ -57,7 +57,9 @@ output(PlyIO::Module, m::MC{F,I}, fn::AbstractString = "test.ply") where {F,I} =
         ),
     )
     vertex_indices = PlyIO.ListProperty("vertex_indices", I, eltype(Triangle))
-    println("Writing $(length(m.vertices)) vertices and $(length(m.triangles)) triangles using `PlyIO`.")
+    println(
+        "Writing $(length(m.vertices)) vertices and $(length(m.triangles)) triangles using `PlyIO`.",
+    )
     for i ∈ eachindex(m.triangles)
         push!(vertex_indices, m.triangles[i] .- 1)  # 1-based indexing -> 0-based indexing
     end

--- a/src/example.jl
+++ b/src/example.jl
@@ -20,34 +20,16 @@
     x^4 - 5x^2 + y^4 - 5y^2 + z^4 - 5z^2 + F(11.8)
 @inline cb_hyperboloid(x, y, z, _...) = x^2 + y^2 - z^2 - 1
 
-callback(case) = if case ≡ :cushin
-    cb_cushin
-elseif case ≡ :torus2
-    cb_torus2
-elseif case ≡ :sphere
-    cb_sphere
-elseif case ≡ :plane
-    cb_plane
-elseif case ≡ :cassini
-    cb_cassini
-elseif case ≡ :blooby
-    cb_blooby
-elseif case ≡ :hyperboloid
-    cb_hyperboloid
-end::Function
+fill_volume!(vol::AbstractArray{F}, callback::Function) where {F} = begin
+    nx, ny, nz = sz = size(vol)
 
-scenario(nx = 60, ny = 60, nz = 60; F = Float32, I = Int32, case = :torus2, kw...) = begin
-    vol = zeros(F, nx, ny, nz)
-
-    sx, sy, sz = F.(size(vol) ./ 16)
+    sx, sy, sz = F.(sz ./ 16)
     tx = F(nx / 2sx)
     ty = F(ny / 2sy + 1.5)
     tz = F(nz / 2sz)
 
-    cb = callback(case)
-
     @inbounds for k ∈ 1:nz, j ∈ 1:ny, i ∈ 1:nx
-        vol[i, j, k] = cb(
+        vol[i, j, k] = callback(
             F((i - 1) / sx - tx),
             F((j - 1) / sy - ty),
             F((k - 1) / sz - tz),
@@ -55,6 +37,30 @@ scenario(nx = 60, ny = 60, nz = 60; F = Float32, I = Int32, case = :torus2, kw..
             F(4),
         )
     end
+
+    nothing
+end
+
+scenario(nx = 60, ny = 60, nz = 60; F = Float32, I = Int32, case = :torus2, kw...) = begin
+    vol = zeros(F, nx, ny, nz)
+
+    callback = if case ≡ :cushin
+        cb_cushin
+    elseif case ≡ :torus2
+        cb_torus2
+    elseif case ≡ :sphere
+        cb_sphere
+    elseif case ≡ :plane
+        cb_plane
+    elseif case ≡ :cassini
+        cb_cassini
+    elseif case ≡ :blooby
+        cb_blooby
+    elseif case ≡ :hyperboloid
+        cb_hyperboloid
+    end::Function
+
+    fill_volume!(vol, callback)
 
     MC(vol, I; kw...)
 end

--- a/src/example.jl
+++ b/src/example.jl
@@ -20,17 +20,16 @@
     x^4 - 5x^2 + y^4 - 5y^2 + z^4 - 5z^2 + F(11.8)
 @inline cb_hyperboloid(x, y, z) = x^2 + y^2 - z^2 - 1
 
-fill_volume!(vol::AbstractArray{F}, callback::Function) where {F} = begin
-    nx, ny, nz = sz = size(vol)
+fill_volume!(vol::AbstractArray{F}, cb::Function) where {F} = begin
+    nx, ny, nz = shape = size(vol)
 
-    sx, sy, sz = F.(sz ./ 16)
+    sx, sy, sz = F.(shape ./ 16)
     tx = F(nx / 2sx)
     ty = F(ny / 2sy + 1.5)
     tz = F(nz / 2sz)
 
     @inbounds for k ∈ 1:nz, j ∈ 1:ny, i ∈ 1:nx
-        vol[i, j, k] =
-            callback(F((i - 1) / sx - tx), F((j - 1) / sy - ty), F((k - 1) / sz - tz))
+        vol[i, j, k] = cb(F((i - 1) / sx - tx), F((j - 1) / sy - ty), F((k - 1) / sz - tz))
     end
 
     nothing

--- a/src/example.jl
+++ b/src/example.jl
@@ -1,24 +1,24 @@
-@inline cb_cushin(x, y, z, _...) = (
+@inline cb_cushin(x, y, z) = (
     z^2 * x^2 - z^4 - 2z * x^2 + 2z^3 + x^2 - z^2 - (x^2 - z)^2 - y^4 - 2x^2 * y^2 -
     y^2 * z^2 +
     2y^2 * z +
     y^2
 )
-@inline cb_torus2(x, y, z, r, R) = (
+@inline cb_torus2(x::F, y::F, z::F, r = F(1.85), R = F(4)) where {F} = (
     ((x^2 + y^2 + z^2 + R^2 - r^2)^2 - 4R^2 * (x^2 + y^2)) *
     ((x^2 + (y + R)^2 + z^2 + R^2 - r^2)^2 - 4R^2 * ((y + R)^2 + z^2))
 )
-@inline cb_sphere(x, y, z, _...) = (
+@inline cb_sphere(x, y, z) = (
     ((x - 2)^2 + (y - 2)^2 + (z - 2)^2 - 1) *
     ((x + 2)^2 + (y - 2)^2 + (z - 2)^2 - 1) *
     ((x - 2)^2 + (y + 2)^2 + (z - 2)^2 - 1)
 )
-@inline cb_plane(x, y, z, _...) = x + y + z - 3
-@inline cb_cassini(x::F, y::F, z::F, _...) where {F} =
+@inline cb_plane(x, y, z) = x + y + z - 3
+@inline cb_cassini(x::F, y::F, z::F) where {F} =
     (x^2 + y^2 + z^2 + F(0.45)^2)^2 - 16 * F(0.45)^2 * (x^2 + z^2) - F(0.5)^2
-@inline cb_blooby(x::F, y::F, z::F, _...) where {F} =
+@inline cb_blooby(x::F, y::F, z::F) where {F} =
     x^4 - 5x^2 + y^4 - 5y^2 + z^4 - 5z^2 + F(11.8)
-@inline cb_hyperboloid(x, y, z, _...) = x^2 + y^2 - z^2 - 1
+@inline cb_hyperboloid(x, y, z) = x^2 + y^2 - z^2 - 1
 
 fill_volume!(vol::AbstractArray{F}, callback::Function) where {F} = begin
     nx, ny, nz = sz = size(vol)
@@ -29,13 +29,8 @@ fill_volume!(vol::AbstractArray{F}, callback::Function) where {F} = begin
     tz = F(nz / 2sz)
 
     @inbounds for k ∈ 1:nz, j ∈ 1:ny, i ∈ 1:nx
-        vol[i, j, k] = callback(
-            F((i - 1) / sx - tx),
-            F((j - 1) / sy - ty),
-            F((k - 1) / sz - tz),
-            F(1.85),
-            F(4),
-        )
+        vol[i, j, k] =
+            callback(F((i - 1) / sx - tx), F((j - 1) / sy - ty), F((k - 1) / sz - tz))
     end
 
     nothing

--- a/src/example.jl
+++ b/src/example.jl
@@ -43,6 +43,9 @@ scenario(nx = 60, ny = 60, nz = 60; F = Float32, I = Int32, case = :torus2, kw..
 end
 
 output(PlyIO::Module, m::MC{F,I}, fn::AbstractString = "test.ply") where {F,I} = begin
+    nv, nt = length(m.vertices), length(m.triangles)
+    println("Writing $nv vertices and $nt triangles using `PlyIO`.")
+
     ply = PlyIO.Ply()
     push!(
         ply,
@@ -56,16 +59,14 @@ output(PlyIO::Module, m::MC{F,I}, fn::AbstractString = "test.ply") where {F,I} =
             PlyIO.ArrayProperty("nz", getindex.(m.normals, 3)),
         ),
     )
+
     vertex_indices = PlyIO.ListProperty("vertex_indices", I, eltype(Triangle))
-    println(
-        "Writing $(length(m.vertices)) vertices and $(length(m.triangles)) triangles using `PlyIO`.",
-    )
     for i ∈ eachindex(m.triangles)
         push!(vertex_indices, m.triangles[i] .- 1)  # 1-based indexing -> 0-based indexing
     end
     push!(ply, PlyIO.PlyElement("face", vertex_indices))
 
-    PlyIO.save_ply(ply, fn, ascii = true)
+    PlyIO.save_ply(ply, fn; ascii = true)
     nothing
 end
 

--- a/src/example.jl
+++ b/src/example.jl
@@ -42,23 +42,24 @@ scenario(nx = 60, ny = 60, nz = 60; F = Float32, I = Int32, case = :torus2, kw..
     MC(vol, I; kw...)
 end
 
-output(PlyIO::Module, m::MC, fn::AbstractString = "test.ply") = begin
+output(PlyIO::Module, m::MC{F,I}, fn::AbstractString = "test.ply") where {F,I} = begin
     ply = PlyIO.Ply()
     push!(
         ply,
         PlyIO.PlyElement(
             "vertex",
-            PlyIO.ArrayProperty("x", map(v -> Float32(v[1]), m.vertices)),
-            PlyIO.ArrayProperty("y", map(v -> Float32(v[2]), m.vertices)),
-            PlyIO.ArrayProperty("z", map(v -> Float32(v[3]), m.vertices)),
-            PlyIO.ArrayProperty("nx", map(n -> Float32(n[1]), m.normals)),
-            PlyIO.ArrayProperty("ny", map(n -> Float32(n[2]), m.normals)),
-            PlyIO.ArrayProperty("nz", map(n -> Float32(n[3]), m.normals)),
+            PlyIO.ArrayProperty("x", getindex.(m.vertices, 1)),
+            PlyIO.ArrayProperty("y", getindex.(m.vertices, 2)),
+            PlyIO.ArrayProperty("z", getindex.(m.vertices, 3)),
+            PlyIO.ArrayProperty("nx", getindex.(m.normals, 1)),
+            PlyIO.ArrayProperty("ny", getindex.(m.normals, 2)),
+            PlyIO.ArrayProperty("nz", getindex.(m.normals, 3)),
         ),
     )
-    vertex_indices = PlyIO.ListProperty("vertex_indices", UInt8, Int32)
+    vertex_indices = PlyIO.ListProperty("vertex_indices", I, eltype(Triangle))
+    println("Writing $(length(m.vertices)) vertices and $(length(m.triangles)) triangles using `PlyIO`.")
     for i ∈ eachindex(m.triangles)
-        push!(vertex_indices, m.triangles[i] .- 1)
+        push!(vertex_indices, m.triangles[i] .- 1)  # 1-based indexing -> 0-based indexing
     end
     push!(ply, PlyIO.PlyElement("face", vertex_indices))
 


### PR DESCRIPTION
Tentative fix for https://github.com/JuliaGeometry/MarchingCubes.jl/issues/21.
Performance improvement of the scenario helpers.

Tested up to 1 billion cells.

```julia
(n, case) = (1, :cushin)
== c++ ==
65536 allocated vertices
nverts=104612 ntrigs=0.
65536 allocated triangles
131072 allocated triangles
Marching Cubes ran in 8.637147 secs.
acc=0 nverts=104616 ntrigs=209252.
Marching Cubes::writePLY(ply/cpp-1.ply)...
   104616 vertices written
   209252 triangles written
 16.081262 seconds (467 allocations: 20.680 KiB, 0.04% compilation time)
== julia ==
  7.939418 seconds (6.68 k allocations: 32.901 GiB, 0.21% gc time, 0.66% compilation time)
  9.920523 seconds
Writing 104616 vertices and 209252 triangles using `PlyIO`.
  0.742114 seconds (7.52 M allocations: 320.140 MiB, 47.54% gc time, 32.46% compilation time)
 18.614792 seconds (7.52 M allocations: 33.214 GiB, 2.04% gc time, 1.59% compilation time)

(n, case) = (2, :torus2)
== c++ ==
65536 allocated vertices
131072 allocated vertices
262144 allocated vertices
524288 allocated vertices
1048576 allocated vertices
2097152 allocated vertices
nverts=3852439 ntrigs=0.
65536 allocated triangles
131072 allocated triangles
262144 allocated triangles
524288 allocated triangles
1048576 allocated triangles
2097152 allocated triangles
4194304 allocated triangles
Marching Cubes ran in 9.806152 secs.
acc=0 nverts=3852439 ntrigs=7703748.
Marching Cubes::writePLY(ply/cpp-2.ply)...
   3852439 vertices written
   7703748 triangles written
 21.167625 seconds (79 allocations: 3.180 KiB)
== julia ==
  6.627018 seconds (56.77 k allocations: 32.905 GiB, 28.53% gc time, 2.79% compilation time)
 10.724688 seconds
Writing 3852439 vertices and 7703748 triangles using `PlyIO`.
 18.387528 seconds (261.94 M allocations: 10.370 GiB, 66.18% gc time)
 35.800220 seconds (262.00 M allocations: 43.275 GiB, 39.41% gc time, 0.52% compilation time)

(n, case) = (3, :sphere)
== c++ ==
65536 allocated vertices
131072 allocated vertices
nverts=257634 ntrigs=0.
65536 allocated triangles
131072 allocated triangles
262144 allocated triangles
Marching Cubes ran in 9.425930 secs.
acc=0 nverts=257634 ntrigs=515256.
Marching Cubes::writePLY(ply/cpp-3.ply)...
   257634 vertices written
   515256 triangles written
 17.970210 seconds (79 allocations: 3.180 KiB)
== julia ==
  7.083647 seconds (48.24 k allocations: 32.904 GiB, 33.64% gc time, 1.73% compilation time)
 10.129331 seconds
Writing 257634 vertices and 515256 triangles using `PlyIO`.
  1.226010 seconds (17.52 M allocations: 714.021 MiB, 66.14% gc time)
 18.491982 seconds (17.57 M allocations: 33.602 GiB, 17.54% gc time, 0.66% compilation time)

(n, case) = (4, :plane)
== c++ ==
65536 allocated vertices
131072 allocated vertices
262144 allocated vertices
524288 allocated vertices
1048576 allocated vertices
2097152 allocated vertices
nverts=2342187 ntrigs=0.
65536 allocated triangles
131072 allocated triangles
262144 allocated triangles
524288 allocated triangles
1048576 allocated triangles
2097152 allocated triangles
4194304 allocated triangles
Marching Cubes ran in 9.890733 secs.
acc=0 nverts=2342187 ntrigs=4677378.
Marching Cubes::writePLY(ply/cpp-4.ply)...
   2342187 vertices written
   4677378 triangles written
 19.688513 seconds (79 allocations: 3.180 KiB)
== julia ==
  6.109468 seconds (41.51 k allocations: 32.904 GiB, 25.33% gc time, 2.15% compilation time)
 10.291157 seconds
Writing 2342187 vertices and 4677378 triangles using `PlyIO`.
 11.204686 seconds (159.15 M allocations: 6.301 GiB, 66.49% gc time)
 27.670420 seconds (159.19 M allocations: 39.205 GiB, 32.69% gc time, 0.47% compilation time)

(n, case) = (5, :cassini)
== c++ ==
65536 allocated vertices
131072 allocated vertices
nverts=177370 ntrigs=0.
65536 allocated triangles
131072 allocated triangles
262144 allocated triangles
Marching Cubes ran in 9.407557 secs.
acc=0 nverts=177370 ntrigs=354736.
Marching Cubes::writePLY(ply/cpp-5.ply)...
   177370 vertices written
   354736 triangles written
 17.073674 seconds (79 allocations: 3.180 KiB)
== julia ==
  6.079665 seconds (45.70 k allocations: 32.904 GiB, 25.24% gc time, 2.04% compilation time)
 10.029241 seconds
Writing 177370 vertices and 354736 triangles using `PlyIO`.
  0.852151 seconds (12.06 M allocations: 489.961 MiB, 64.81% gc time)
 17.012540 seconds (12.10 M allocations: 33.383 GiB, 12.56% gc time, 0.73% compilation time)

(n, case) = (6, :blooby)
== c++ ==
65536 allocated vertices
131072 allocated vertices
262144 allocated vertices
524288 allocated vertices
nverts=696772 ntrigs=0.
65536 allocated triangles
131072 allocated triangles
262144 allocated triangles
524288 allocated triangles
1048576 allocated triangles
Marching Cubes ran in 9.511189 secs.
acc=0 nverts=696772 ntrigs=1393560.
Marching Cubes::writePLY(ply/cpp-6.ply)...
   696772 vertices written
   1393560 triangles written
 18.730443 seconds (79 allocations: 3.180 KiB)
== julia ==
 10.976162 seconds (44.06 k allocations: 32.904 GiB, 14.56% gc time, 1.01% compilation time)
 10.199074 seconds
Writing 696772 vertices and 1393560 triangles using `PlyIO`.
  3.396271 seconds (47.38 M allocations: 1.877 GiB, 67.28% gc time)
 24.631311 seconds (47.42 M allocations: 34.781 GiB, 15.98% gc time, 0.45% compilation time)

(n, case) = (7, :hyperboloid)
== c++ ==
65536 allocated vertices
131072 allocated vertices
262144 allocated vertices
524288 allocated vertices
1048576 allocated vertices
2097152 allocated vertices
nverts=3777303 ntrigs=0.
65536 allocated triangles
131072 allocated triangles
262144 allocated triangles
524288 allocated triangles
1048576 allocated triangles
2097152 allocated triangles
4194304 allocated triangles
Marching Cubes ran in 10.205976 secs.
acc=0 nverts=3777303 ntrigs=7548106.
Marching Cubes::writePLY(ply/cpp-7.ply)...
   3777303 vertices written
   7548106 triangles written
 21.614600 seconds (79 allocations: 3.180 KiB)
== julia ==
  6.064651 seconds (42.17 k allocations: 32.904 GiB, 25.06% gc time, 2.01% compilation time)
 10.582340 seconds
Writing 3777303 vertices and 7548106 triangles using `PlyIO`.
 18.108875 seconds (256.74 M allocations: 10.170 GiB, 66.42% gc time)
 34.825347 seconds (256.79 M allocations: 43.074 GiB, 39.04% gc time, 0.35% compilation time)
```