### PR TITLE
Attempt to handle `AbstractRange` types for coordinate vectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.10'  # latest LTS
+          - 'lts'
           - '1'
         experimental:
           - false

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -30,6 +30,7 @@ jobs:
             else
                 @error "Some files have not been formatted !!!"
                 write(stdout, out)
+                run(`git diff`)
                 exit(1)
             end
           '

--- a/src/MarchingCubes.jl
+++ b/src/MarchingCubes.jl
@@ -62,26 +62,17 @@ struct MC{F,I}
     vertices::Vector{Vertex{F}}  # output vertex positions
     normals::Vector{Normal{F}}  # output vertex normals
     normal_sign::Int  # direction of normal vectors (+1 for outward / -1 for inward)
-    x::RefValue{Vector{F}}
-    y::RefValue{Vector{F}}
-    z::RefValue{Vector{F}}
+    x::RefValue{<:AbstractVector{F}}
+    y::RefValue{<:AbstractVector{F}}
+    z::RefValue{<:AbstractVector{F}}
     MC(
         vol::Array{F,3},
         I::Type{G} = Int;
         normal_sign::Integer = 1,
-        x::Union{AbstractVector{F}, AbstractRange{F}} = F[],
-        y::Union{AbstractVector{F}, AbstractRange{F}} = F[],
-        z::Union{AbstractVector{F}, AbstractRange{F}} = F[],
+        x::AbstractVector{F} = F[],
+        y::AbstractVector{F} = F[],
+        z::AbstractVector{F} = F[],
     ) where {F<:AbstractFloat,G<:Integer} = begin
-        if isa(x,AbstractRange)
-            x = collect(x)
-        end
-        if isa(y,AbstractRange)
-            y = collect(y)
-        end
-        if isa(z,AbstractRange)
-            z = collect(z)
-        end
         abs(normal_sign) == 1 || throw(ArgumentError("`normal_sign` should be either -1 or +1"))
         m = new{F,I}(
             size(vol)...,

--- a/src/MarchingCubes.jl
+++ b/src/MarchingCubes.jl
@@ -69,10 +69,19 @@ struct MC{F,I}
         vol::Array{F,3},
         I::Type{G} = Int;
         normal_sign::Integer = 1,
-        x::AbstractVector{F} = F[],
-        y::AbstractVector{F} = F[],
-        z::AbstractVector{F} = F[],
+        x::Union{AbstractVector{F}, AbstractRange{F}} = F[],
+        y::Union{AbstractVector{F}, AbstractRange{F}} = F[],
+        z::Union{AbstractVector{F}, AbstractRange{F}} = F[],
     ) where {F<:AbstractFloat,G<:Integer} = begin
+        if isa(x,AbstractRange)
+            x = collect(x)
+        end
+        if isa(y,AbstractRange)
+            y = collect(y)
+        end
+        if isa(z,AbstractRange)
+            z = collect(z)
+        end
         abs(normal_sign) == 1 || throw(ArgumentError("`normal_sign` should be either -1 or +1"))
         m = new{F,I}(
             size(vol)...,

--- a/src/MarchingCubes.jl
+++ b/src/MarchingCubes.jl
@@ -76,7 +76,8 @@ struct MC{F,I}
         isa(x, AbstractRange) && (x = collect(x))
         isa(y, AbstractRange) && (y = collect(y))
         isa(z, AbstractRange) && (z = collect(z))
-        abs(normal_sign) == 1 || throw(ArgumentError("`normal_sign` should be either -1 or +1"))
+        abs(normal_sign) == 1 ||
+        throw(ArgumentError("`normal_sign` should be either -1 or +1"))
         m = new{F,I}(
             size(vol)...,
             Ref(vol),

--- a/src/MarchingCubes.jl
+++ b/src/MarchingCubes.jl
@@ -62,9 +62,9 @@ struct MC{F,I}
     vertices::Vector{Vertex{F}}  # output vertex positions
     normals::Vector{Normal{F}}  # output vertex normals
     normal_sign::Int  # direction of normal vectors (+1 for outward / -1 for inward)
-    x::RefValue{<:AbstractVector{F}}
-    y::RefValue{<:AbstractVector{F}}
-    z::RefValue{<:AbstractVector{F}}
+    x::RefValue{Vector{F}}
+    y::RefValue{Vector{F}}
+    z::RefValue{Vector{F}}
     MC(
         vol::Array{F,3},
         I::Type{G} = Int;
@@ -73,6 +73,9 @@ struct MC{F,I}
         y::AbstractVector{F} = F[],
         z::AbstractVector{F} = F[],
     ) where {F<:AbstractFloat,G<:Integer} = begin
+        isa(x, AbstractRange) && (x = collect(x))
+        isa(y, AbstractRange) && (y = collect(y))
+        isa(z, AbstractRange) && (z = collect(z))
         abs(normal_sign) == 1 || throw(ArgumentError("`normal_sign` should be either -1 or +1"))
         m = new{F,I}(
             size(vol)...,

--- a/src/example.jl
+++ b/src/example.jl
@@ -126,7 +126,7 @@ makemesh_GeometryBasics(GeometryBasics::Module, m::MC) = begin
     vertices = map(GeometryBasics.Point3f, m.vertices)
     normals = map(GeometryBasics.Vec3f, m.normals)
     triangles = map(t -> GeometryBasics.TriangleFace(t...), m.triangles)
-    GeometryBasics.Mesh(vertices, triangles; normal=normals)
+    GeometryBasics.Mesh(vertices, triangles; normal = normals)
 end
 
 makemesh(mod::Module, m::MC) =

--- a/src/example.jl
+++ b/src/example.jl
@@ -126,7 +126,7 @@ makemesh_GeometryBasics(GeometryBasics::Module, m::MC) = begin
     vertices = map(GeometryBasics.Point3f, m.vertices)
     normals = map(GeometryBasics.Vec3f, m.normals)
     triangles = map(t -> GeometryBasics.TriangleFace(t...), m.triangles)
-    GeometryBasics.Mesh(GeometryBasics.meta(vertices; normals), triangles)
+    GeometryBasics.Mesh(vertices, triangles; normal=normals)
 end
 
 makemesh(mod::Module, m::MC) =

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -223,7 +223,7 @@ end
     # Test if coordinate input was used appropriately geometrically as expected    
     n = length(mc_ranged.vertices)
     c = sum(mc_ranged.vertices)/n # Mean coordinate i.e. centre 
-    r = sum(v -> sqrt(sum(v.^2)),mc_ranged.vertices)/n # Mean radius     
+    r = sum(v -> sqrt(sum(v.^2)), mc_ranged.vertices)/n # Mean radius     
     @test isapprox(c,[0.0,0.0,0.0], atol = epsLevel) # Approximately zero mean for sphere     
     @test isapprox(r, level, atol = epsLevel) # Approximately radius matching level
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,11 +209,11 @@ end
     level = 0.5 # isolevel should produce sphere with this radius
 
     # Process isosurface with ranged coordinate input
-    mc_ranged = MC(A,Int; x=x, y=y, z=z)
+    mc_ranged = MC(A,Int; x = x, y = y, z = z)
     march(mc_ranged,level)
 
     # Process isosurface with vector coordinate input
-    mc_vector = MC(A,Int; x=collect(Float64, x), y=collect(Float64, y), z=collect(Float64, z))
+    mc_vector = MC(A,Int; x = collect(Float64, x), y = collect(Float64, y), z = collect(Float64, z))
     march(mc_vector,level)
 
     # Test equivalence between ranged and vector input

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,7 +187,7 @@ end
     msh = MarchingCubes.makemesh(GeometryBasics, mc)
     @test msh isa GeometryBasics.Mesh
     @test length(msh.position) == length(mc.vertices)
-    @test length(msh.normals) == length(mc.normals)
+    @test length(msh.normal) == length(mc.normals)
 
     @test_throws ArgumentError MarchingCubes.makemesh(PlyIO, mc)
 end


### PR DESCRIPTION
@t-bltg thanks for developing MarchingCubes.jl! I am working on using it in my [Comodo.jl](https://github.com/COMODO-research/Comodo.jl) package. 

I wanted to extend MarchingCubes to allow for range type coordinate input, i.e. such that when using this: 
```
mc = MarchingCubes.MC(A,Int; x=xr, y=yr, z=zr)
```
the entries `xr` etc can be of the type `AbstractRange`. 

Currently I think I implemented a very basic fix, but perhaps you can point me to improving it if what I propose is not efficient. 

In `MarchingCubes.jl` I changed the types from `AbstractVector{F} = F[],` to `Union{AbstractVector{F}, AbstractRange{F}} = F[],`
Next in the definition of `MC` I added stuff like the below to collect the range into a vector before it is passed to `Ref(x)` : 
```
       if isa(x,AbstractRange)
            x = collect(x)
        end
```
I did the simple `collect` mainly because I could not quickly figure out how to use/fix that `Ref` and `RefValue` business, so any advise on that is welcome. 

Below is the code I used for testing (which also contains Makie based visualisation): 
```julia
using LinearAlgebra
using GLMakie
using GeometryBasics
using MarchingCubes

# Define image matrix
nSteps = 50 
xr,yr,zr = ntuple(_->range(-1.0,1.0,nSteps),3) # Coordinate ranges 
A = [norm((x,y,z)) for x in xr, y in yr, z in zr] # Image 

# Using MarchingCubes to get the isosurface 
level = 0.5 # Level for isosurface 
mc = MarchingCubes.MC(A,Int; x=xr, y=yr, z=zr)
MarchingCubes.march(mc,level)

# Access faces and vertices and poor in GeometryBasics format to enable Makie based visualisation
F = [TriangleFace{Int64}(f) for f in mc.triangles]
V = [Point{3,Float64}(p) for p in mc.vertices]

# Visualization
fig = Figure(size=(800,800))
ax1 = Axis3(fig[1, 1], aspect = :data, xlabel = "X", ylabel = "Y", zlabel = "Z", limits=(minimum(xr),maximum(xr),minimum(yr),maximum(yr),minimum(zr),maximum(zr)))
hp1 = poly!(ax1,GeometryBasics.Mesh(V,F), strokewidth=1, strokecolor=:black, color=:white,shading=FastShading,transparency=false)
fig
```

![image](https://github.com/user-attachments/assets/f8d0be9a-7b5d-47ad-8a11-79c9f319e945)

Let me know if this is going in a direction you like or if the feature is not at all of interest (or what changes would be needed to have it fit). 

Thanks! 